### PR TITLE
fix(api): enforce not-found semantics for no-op writes (#12)

### DIFF
--- a/orbit.go
+++ b/orbit.go
@@ -61,6 +61,26 @@ type Store struct {
 	db *sql.DB
 }
 
+var errWriteTargetNotFound = errors.New("write target not found")
+
+func writeTargetNotFoundError(action, id, contextID string) error {
+	if contextID == "" {
+		return fmt.Errorf("%s item %q: %w", action, id, errors.Join(errWriteTargetNotFound, sql.ErrNoRows))
+	}
+	return fmt.Errorf("%s item %q in context %q: %w", action, id, contextOrDefault(contextID), errors.Join(errWriteTargetNotFound, sql.ErrNoRows))
+}
+
+func requireRowsAffected(result sql.Result, operation string, onZero error) error {
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("%s rows affected: %w", operation, err)
+	}
+	if rowsAffected == 0 {
+		return onZero
+	}
+	return nil
+}
+
 func newStore(dbPath string) (*Store, error) {
 	hadDB, initializedFlag, err := prepareStorePath(dbPath)
 	if err != nil {
@@ -285,17 +305,23 @@ ON CONFLICT(id) DO UPDATE SET
 }
 
 func (s *Store) delete(id string) error {
-	_, err := s.db.Exec(`DELETE FROM items WHERE id = ?`, id)
+	result, err := s.db.Exec(`DELETE FROM items WHERE id = ?`, id)
 	if err != nil {
 		return fmt.Errorf("delete item %q: %w", id, err)
+	}
+	if err := requireRowsAffected(result, fmt.Sprintf("delete item %q", id), writeTargetNotFoundError("delete", id, "")); err != nil {
+		return err
 	}
 	return nil
 }
 
 func (s *Store) setCompleted(id string, completed bool) error {
-	_, err := s.db.Exec(`UPDATE items SET completed=?, updated_at=? WHERE id=?`, boolToInt(completed), time.Now().Format(time.RFC3339Nano), id)
+	result, err := s.db.Exec(`UPDATE items SET completed=?, updated_at=? WHERE id=?`, boolToInt(completed), time.Now().Format(time.RFC3339Nano), id)
 	if err != nil {
 		return fmt.Errorf("set item %q completed=%t: %w", id, completed, err)
+	}
+	if err := requireRowsAffected(result, fmt.Sprintf("set item %q completed=%t", id, completed), writeTargetNotFoundError("set completed", id, "")); err != nil {
+		return err
 	}
 	return nil
 }
@@ -394,9 +420,12 @@ func (s *Store) applyTouchState(it *Item) error {
 }
 
 func (s *Store) hide(id, contextID string) error {
-	_, err := s.db.Exec(`UPDATE items SET hidden=1, updated_at=? WHERE id = ? AND context_id = ?`, time.Now().Format(time.RFC3339Nano), id, contextOrDefault(contextID))
+	result, err := s.db.Exec(`UPDATE items SET hidden=1, updated_at=? WHERE id = ? AND context_id = ?`, time.Now().Format(time.RFC3339Nano), id, contextOrDefault(contextID))
 	if err != nil {
 		return fmt.Errorf("hide item %q in context %q: %w", id, contextOrDefault(contextID), err)
+	}
+	if err := requireRowsAffected(result, fmt.Sprintf("hide item %q in context %q", id, contextOrDefault(contextID)), writeTargetNotFoundError("hide", id, contextID)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -441,9 +470,12 @@ func (s *Store) hiddenItems(contextID string) ([]Item, error) {
 }
 
 func (s *Store) unhideAt(id, contextID string, x, y float64) error {
-	_, err := s.db.Exec(`UPDATE items SET hidden=0, x=?, y=?, updated_at=? WHERE id=? AND context_id=?`, x, y, time.Now().Format(time.RFC3339Nano), id, contextOrDefault(contextID))
+	result, err := s.db.Exec(`UPDATE items SET hidden=0, x=?, y=?, updated_at=? WHERE id=? AND context_id=?`, x, y, time.Now().Format(time.RFC3339Nano), id, contextOrDefault(contextID))
 	if err != nil {
 		return fmt.Errorf("unhide item %q in context %q: %w", id, contextOrDefault(contextID), err)
+	}
+	if err := requireRowsAffected(result, fmt.Sprintf("unhide item %q in context %q", id, contextOrDefault(contextID)), writeTargetNotFoundError("unhide", id, contextID)); err != nil {
+		return err
 	}
 	return nil
 }
@@ -697,9 +729,12 @@ func (s *Store) deleteContext(id string) error {
 	if id == "main-orbit" {
 		return errors.New("cannot delete Main Orbit")
 	}
-	_, err := s.db.Exec(`DELETE FROM contexts WHERE id=?`, id)
+	result, err := s.db.Exec(`DELETE FROM contexts WHERE id=?`, id)
 	if err != nil {
 		return fmt.Errorf("delete context %q: %w", id, err)
+	}
+	if err := requireRowsAffected(result, fmt.Sprintf("delete context %q", id), fmt.Errorf("delete context %q: %w", id, errors.Join(errWriteTargetNotFound, sql.ErrNoRows))); err != nil {
+		return err
 	}
 	return nil
 }
@@ -894,6 +929,10 @@ func (a *App) deleteItemAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.store.delete(in.ID); err != nil {
+		if errors.Is(err, errWriteTargetNotFound) {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -925,6 +964,10 @@ func (a *App) completeItemAPI(w http.ResponseWriter, r *http.Request) {
 		completed = *in.Completed
 	}
 	if err := a.store.setCompleted(in.ID, completed); err != nil {
+		if errors.Is(err, errWriteTargetNotFound) {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1047,6 +1090,10 @@ func (a *App) hideItemAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.store.hide(in.ID, in.ContextID); err != nil {
+		if errors.Is(err, errWriteTargetNotFound) {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1135,6 +1182,10 @@ func (a *App) unhideAtAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.store.unhideAt(in.ID, in.ContextID, in.X, in.Y); err != nil {
+		if errors.Is(err, errWriteTargetNotFound) {
+			http.Error(w, "item not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1273,6 +1324,10 @@ func (a *App) deleteContextAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := a.store.deleteContext(id); err != nil {
+		if errors.Is(err, errWriteTargetNotFound) {
+			http.Error(w, "context not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/orbit_test.go
+++ b/orbit_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"html/template"
 	"net"
 	"net/http"
@@ -253,6 +254,22 @@ func TestDeleteItemAPIRemovesCard(t *testing.T) {
 	}
 }
 
+func TestDeleteItemAPINotFoundOnMissingTarget(t *testing.T) {
+	s, _ := newTestStore(t)
+	app := &App{store: s}
+
+	rr := postJSON(t, app.deleteItemAPI, map[string]any{"id": "missing-delete-target"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing delete target, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `{"ok":true`) {
+		t.Fatalf("missing delete target must not return success payload: %s", rr.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(rr.Body.String()), "not found") {
+		t.Fatalf("expected not-found response body, got: %s", rr.Body.String())
+	}
+}
+
 func TestCompleteItemAPIMarksItemCompletedAndRemovesFromSnapshot(t *testing.T) {
 	s, _ := newTestStore(t)
 	app := &App{store: s}
@@ -364,6 +381,25 @@ func TestCompleteItemAPIUndoRestoresItemInOriginalContext(t *testing.T) {
 	}
 }
 
+func TestCompleteItemAPINotFoundOnMissingTarget(t *testing.T) {
+	s, _ := newTestStore(t)
+	app := &App{store: s}
+
+	rr := postJSON(t, app.completeItemAPI, map[string]any{
+		"id":        "missing-complete-target",
+		"completed": true,
+	})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing complete target, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `{"ok":true`) {
+		t.Fatalf("missing complete target must not return success payload: %s", rr.Body.String())
+	}
+	if !strings.Contains(strings.ToLower(rr.Body.String()), "not found") {
+		t.Fatalf("expected not-found response body, got: %s", rr.Body.String())
+	}
+}
+
 func TestDeleteContextAPICascadesItems(t *testing.T) {
 	s, _ := newTestStore(t)
 	app := &App{store: s}
@@ -433,6 +469,19 @@ func TestDeleteContextAPIMainOrbitRejected(t *testing.T) {
 	}
 	if n != 1 {
 		t.Fatalf("expected main-orbit to still exist, count=%d", n)
+	}
+}
+
+func TestDeleteContextAPINotFoundOnMissingTarget(t *testing.T) {
+	s, _ := newTestStore(t)
+	app := &App{store: s}
+
+	rr := postJSON(t, app.deleteContextAPI, map[string]any{"id": "missing-context-target"})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for missing context delete target, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `{"ok":true`) {
+		t.Fatalf("missing context delete must not return success payload: %s", rr.Body.String())
 	}
 }
 
@@ -556,6 +605,55 @@ func TestHideItemAPIUpdatesHiddenFlagAndCount(t *testing.T) {
 	}
 }
 
+func TestHideItemAPIWrongContextReturnsNotFound(t *testing.T) {
+	s, _ := newTestStore(t)
+	app := &App{store: s}
+
+	const itemID = "t_hide_wrong_ctx_1"
+	const trueContextID = "t_ctx_hide_true"
+	const wrongContextID = "t_ctx_hide_wrong"
+	for _, c := range []Context{
+		{ID: trueContextID, Title: "True", SubNote: "", X: 500, Y: 300, Color: "var(--c2)"},
+		{ID: wrongContextID, Title: "Wrong", SubNote: "", X: 600, Y: 350, Color: "var(--c3)"},
+	} {
+		if err := s.upsertContext(c); err != nil {
+			t.Fatalf("seed context %q: %v", c.ID, err)
+		}
+	}
+	if err := s.update(Item{
+		ID:        itemID,
+		ContextID: trueContextID,
+		Title:     "hide-wrong-context",
+		SubNote:   "",
+		X:         111,
+		Y:         222,
+		Color:     "var(--c1)",
+	}); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	// Deterministic choice: wrong context is treated as item-not-found (404).
+	rr := postJSON(t, app.hideItemAPI, map[string]any{
+		"id":        itemID,
+		"contextId": wrongContextID,
+	})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for hide wrong context, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `{"ok":true`) {
+		t.Fatalf("wrong-context hide must not return success payload: %s", rr.Body.String())
+	}
+
+	var hidden int
+	var contextID string
+	if err := s.db.QueryRow(`SELECT hidden,context_id FROM items WHERE id=?`, itemID).Scan(&hidden, &contextID); err != nil {
+		t.Fatalf("query item after wrong-context hide: %v", err)
+	}
+	if hidden != 0 || contextID != trueContextID {
+		t.Fatalf("wrong-context hide mutated row unexpectedly: hidden=%d context=%q", hidden, contextID)
+	}
+}
+
 func TestUnhideAtAPIRestoresVisibilityAndPosition(t *testing.T) {
 	s, _ := newTestStore(t)
 	app := &App{store: s}
@@ -599,6 +697,158 @@ func TestUnhideAtAPIRestoresVisibilityAndPosition(t *testing.T) {
 	})
 	assertUnhideAtResponse(t, rr, targetX, targetY)
 	assertStoredItemVisibilityAndPosition(t, s, "t_hide_item_2", targetX, targetY)
+}
+
+func TestUnhideAtAPIWrongContextReturnsNotFound(t *testing.T) {
+	s, _ := newTestStore(t)
+	app := &App{store: s}
+
+	const itemID = "t_unhide_wrong_ctx_1"
+	const trueContextID = "t_ctx_unhide_true"
+	const wrongContextID = "t_ctx_unhide_wrong"
+	for _, c := range []Context{
+		{ID: trueContextID, Title: "True", SubNote: "", X: 520, Y: 320, Color: "var(--c3)"},
+		{ID: wrongContextID, Title: "Wrong", SubNote: "", X: 610, Y: 360, Color: "var(--c4)"},
+	} {
+		if err := s.upsertContext(c); err != nil {
+			t.Fatalf("seed context %q: %v", c.ID, err)
+		}
+	}
+	if err := s.update(Item{
+		ID:        itemID,
+		ContextID: trueContextID,
+		Title:     "unhide-wrong-context",
+		SubNote:   "",
+		X:         10,
+		Y:         20,
+		Color:     "var(--c1)",
+	}); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	if err := s.hide(itemID, trueContextID); err != nil {
+		t.Fatalf("hide seeded item: %v", err)
+	}
+
+	// Deterministic choice: wrong context is treated as item-not-found (404).
+	rr := postJSON(t, app.unhideAtAPI, map[string]any{
+		"id":        itemID,
+		"contextId": wrongContextID,
+		"x":         333.0,
+		"y":         444.0,
+	})
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unhide-at wrong context, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if strings.Contains(rr.Body.String(), `{"ok":true`) {
+		t.Fatalf("wrong-context unhide-at must not return success payload: %s", rr.Body.String())
+	}
+
+	var hidden int
+	var x, y float64
+	var contextID string
+	if err := s.db.QueryRow(`SELECT hidden,x,y,context_id FROM items WHERE id=?`, itemID).Scan(&hidden, &x, &y, &contextID); err != nil {
+		t.Fatalf("query item after wrong-context unhide-at: %v", err)
+	}
+	if hidden != 1 || x != 10 || y != 20 || contextID != trueContextID {
+		t.Fatalf("wrong-context unhide-at mutated row unexpectedly: hidden=%d x=%v y=%v context=%q", hidden, x, y, contextID)
+	}
+}
+
+func TestStoreDeleteNoOpReturnsNotFoundError(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	err := s.delete("missing-store-delete-target")
+	if err == nil {
+		t.Fatal("expected delete no-op to return error")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected delete no-op to wrap sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestStoreSetCompletedNoOpReturnsNotFoundError(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	err := s.setCompleted("missing-store-complete-target", true)
+	if err == nil {
+		t.Fatal("expected setCompleted no-op to return error")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected setCompleted no-op to wrap sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestStoreHideWrongContextNoOpReturnsNotFoundError(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	const itemID = "t_store_hide_wrong_ctx_1"
+	const trueContextID = "t_store_hide_true"
+	const wrongContextID = "t_store_hide_wrong"
+	for _, c := range []Context{
+		{ID: trueContextID, Title: "True", SubNote: "", X: 100, Y: 100, Color: "var(--c2)"},
+		{ID: wrongContextID, Title: "Wrong", SubNote: "", X: 200, Y: 200, Color: "var(--c3)"},
+	} {
+		if err := s.upsertContext(c); err != nil {
+			t.Fatalf("seed context %q: %v", c.ID, err)
+		}
+	}
+	if err := s.update(Item{
+		ID:        itemID,
+		ContextID: trueContextID,
+		Title:     "store-hide-wrong-context",
+		SubNote:   "",
+		X:         11,
+		Y:         22,
+		Color:     "var(--c1)",
+	}); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+
+	err := s.hide(itemID, wrongContextID)
+	if err == nil {
+		t.Fatal("expected hide wrong-context no-op to return error")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected hide wrong-context no-op to wrap sql.ErrNoRows, got: %v", err)
+	}
+}
+
+func TestStoreUnhideAtWrongContextNoOpReturnsNotFoundError(t *testing.T) {
+	s, _ := newTestStore(t)
+
+	const itemID = "t_store_unhide_wrong_ctx_1"
+	const trueContextID = "t_store_unhide_true"
+	const wrongContextID = "t_store_unhide_wrong"
+	for _, c := range []Context{
+		{ID: trueContextID, Title: "True", SubNote: "", X: 100, Y: 100, Color: "var(--c2)"},
+		{ID: wrongContextID, Title: "Wrong", SubNote: "", X: 200, Y: 200, Color: "var(--c3)"},
+	} {
+		if err := s.upsertContext(c); err != nil {
+			t.Fatalf("seed context %q: %v", c.ID, err)
+		}
+	}
+	if err := s.update(Item{
+		ID:        itemID,
+		ContextID: trueContextID,
+		Title:     "store-unhide-wrong-context",
+		SubNote:   "",
+		X:         11,
+		Y:         22,
+		Color:     "var(--c1)",
+	}); err != nil {
+		t.Fatalf("seed item: %v", err)
+	}
+	if err := s.hide(itemID, trueContextID); err != nil {
+		t.Fatalf("hide seed item: %v", err)
+	}
+
+	err := s.unhideAt(itemID, wrongContextID, 333, 444)
+	if err == nil {
+		t.Fatal("expected unhide-at wrong-context no-op to return error")
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("expected unhide-at wrong-context no-op to wrap sql.ErrNoRows, got: %v", err)
+	}
 }
 
 func TestRevealAllAPIReturnsItemsAndClearsHiddenSet(t *testing.T) {


### PR DESCRIPTION
## Summary
Cherry-picks issue #12 fix into a PR-safe linear branch for protected `master`.

## Why this PR
Direct push to `master` is blocked by branch protections:
- PR-only updates
- no merge commits
- required `go-lint-strict / lint` status check

## Included change
- `cfa90ef` (`fix(api): enforce not-found semantics for no-op writes`)

## Scope
- `orbit.go`
- `orbit_test.go`

## Validation
- `go test . -run 'Test(DeleteItemAPI|CompleteItemAPI|HideItemAPI|UnhideAtAPI|Store|DeleteContextAPI).*NotFound|NoOp|WrongContext|Missing|DeleteContext' -count=1`
- `golangci-lint run ./...`
- `gocyclo -over 14 orbit.go`
