### PR TITLE
fix(ui): explicit save failure handling for context/card saves (#14)

### DIFF
--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -1378,6 +1378,56 @@ test('context title is editable in focus view and persists after reload', async 
   expect(contextBox!.x + contextBox!.width).toBeLessThanOrEqual(surfaceBox!.x + surfaceBox!.width);
 });
 
+test('context title save failure restores previous value and shows warning', async ({ page }) => {
+  const name = page.locator('#context-name');
+  await expect(name).toBeVisible();
+  const previousTitle = ((await name.textContent()) || '').trim() || 'Main Orbit';
+  let failedOnce = false;
+
+  await page.route('**/api/contexts', async (route, request) => {
+    if (!failedOnce && request.method() === 'POST') {
+      failedOnce = true;
+      await route.fulfill({ status: 500, body: 'context save failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  const nextTitle = `ctx-fail-${Date.now()}`;
+  await name.focus();
+  await name.evaluate((el, value) => {
+    el.textContent = String(value);
+    (el as HTMLElement).blur();
+  }, nextTitle);
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to save context title. Restored previous value.');
+  await expect(name).toHaveText(previousTitle);
+  expect(failedOnce).toBeTruthy();
+});
+
+test('card save failure keeps local draft unsaved and shows warning', async ({ page }) => {
+  const pin = page.locator('.pin').first();
+  await expect(pin).toBeVisible();
+  const titleInput = pin.locator('.pin-title input');
+  const nextTitle = `card-fail-${Date.now()}`;
+  let failedOnce = false;
+
+  await page.route('**/api/items', async (route, request) => {
+    if (!failedOnce && request.method() === 'POST') {
+      failedOnce = true;
+      await route.fulfill({ status: 500, body: 'item save failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await titleInput.fill(nextTitle);
+  await titleInput.blur();
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to save card changes. Your edits are kept locally.');
+  await expect(titleInput).toHaveValue(nextTitle);
+  await expect(pin).toHaveAttribute('data-saved', 'false');
+  expect(failedOnce).toBeTruthy();
+});
+
 test('card note height increases from one line to two lines', async ({ page }) => {
   const pin = page.locator('.pin').first();
   await expect(pin).toBeVisible();

--- a/static/app.js
+++ b/static/app.js
@@ -85,6 +85,30 @@
   toolbar.append(colorsPanel, filtersTray);
   const contextNameEl = document.getElementById('context-name');
   const openContextsEl = document.getElementById('open-contexts');
+  let contextTitlePersisted = contextNameEl ? ((contextNameEl.textContent || '').trim() || 'Main Orbit') : 'Main Orbit';
+  let contextTitleSaveSeq = 0;
+  async function persistContextTitle(){
+    if (!contextNameEl) return;
+    const nextTitle = (contextNameEl.textContent || '').trim() || 'Main Orbit';
+    contextNameEl.textContent = nextTitle;
+    const previousTitle = contextTitlePersisted;
+    if (nextTitle === previousTitle) return;
+    const saveSeq = ++contextTitleSaveSeq;
+    try {
+      const res = await fetch('/api/contexts', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({id: currentContextId, title: nextTitle})
+      });
+      if (saveSeq !== contextTitleSaveSeq) return;
+      if (!res.ok) throw new Error(`context title save failed (${res.status})`);
+      contextTitlePersisted = nextTitle;
+    } catch (_err) {
+      if (saveSeq !== contextTitleSaveSeq) return;
+      contextNameEl.textContent = previousTitle;
+      showCanvasWarning('Unable to save context title. Restored previous value.');
+    }
+  }
   if (mode === 'focus' && contextNameEl) {
     contextNameEl.contentEditable = 'true';
     contextNameEl.addEventListener('pointerdown', (ev) => ev.stopPropagation());
@@ -96,9 +120,7 @@
       sel.removeAllRanges();
       sel.addRange(r);
     });
-    contextNameEl.addEventListener('blur', () => {
-      fetch('/api/contexts', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({id: currentContextId, title: contextNameEl.textContent || 'Main Orbit'})});
-    });
+    contextNameEl.addEventListener('blur', () => { persistContextTitle(); });
   }
   if (openContextsEl) {
     openContextsEl.addEventListener('pointerdown', (ev) => ev.stopPropagation());
@@ -732,6 +754,7 @@
   }
 
   const pending = new Map();
+  const saveRequestSeq = new Map();
 
   function markPersisted(pin){
     pin.dataset.persistedTitle = pin.querySelector('.pin-title input').value;
@@ -763,18 +786,27 @@
     const id = pin.dataset.id;
     const payload = pinPayload(pin);
     cancelPendingSave(id);
-    pending.set(id, setTimeout(() => {
-      fetch(mode === 'focus' ? '/api/items' : '/api/contexts', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify(payload)
-      }).then(async (res) => {
-        if (!res.ok) return;
+    pending.set(id, setTimeout(async () => {
+      const saveSeq = (saveRequestSeq.get(id) || 0) + 1;
+      saveRequestSeq.set(id, saveSeq);
+      try {
+        const res = await fetch(mode === 'focus' ? '/api/items' : '/api/contexts', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify(payload)
+        });
+        if (saveRequestSeq.get(id) !== saveSeq) return;
+        if (!res.ok) throw new Error(`save failed (${res.status})`);
         const data = await res.json().catch(() => null);
+        if (saveRequestSeq.get(id) !== saveSeq) return;
         if (data) applyTouchResponse(pin, data);
         pin.dataset.saved = 'true';
         markPersisted(pin);
-      });
+      } catch (_err) {
+        if (saveRequestSeq.get(id) !== saveSeq) return;
+        pin.dataset.saved = 'false';
+        showCanvasWarning(mode === 'focus' ? 'Unable to save card changes. Your edits are kept locally.' : 'Unable to save context changes. Your edits are kept locally.');
+      }
     }, 180));
   }
 


### PR DESCRIPTION
## Summary
- Add explicit success/failure handling for context title blur save.
- Add explicit success/failure handling for `savePin` (no more silent non-OK swallow).
- On save failure: show deterministic warning and keep draft unsaved instead of silently committing.
- Add Playwright regressions for context-title save failure and card save failure.

## Files
- `static/app.js`
- `e2e/core-ui.spec.ts`

## Verification
- `npm run test:ui -- --grep "context title save failure|card save failure"`
- `npm run test:ui -- --grep "context title is editable in focus view and persists after reload|context title save failure|card save failure"`
