### PR TITLE
fix(ui): prevent hide commit before server ack (#15)

### DIFF
--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -939,6 +939,36 @@ test('hide/unhide updates hidden tray count accurately', async ({ page }) => {
   await expect.poll(() => getHiddenCount(page)).toBe(initialCount);
 });
 
+test('hide failure keeps card visible and shows warning', async ({ page }) => {
+  const title = `hide-fail-${Date.now()}`;
+  const created = await createCard(page, title);
+  const id = await created.getAttribute('data-id');
+  expect(id).toBeTruthy();
+  const initialCount = await getHiddenCount(page);
+  let failedOnce = false;
+
+  await page.route('**/api/items/hide', async (route, request) => {
+    if (!failedOnce && request.method() === 'POST') {
+      failedOnce = true;
+      await route.fulfill({ status: 500, body: 'hide failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await ensureFiltersTrayOpen(page);
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-hide').click();
+
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to hide card. Please try again.');
+  await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(1);
+  await expect.poll(() => getHiddenCount(page)).toBe(initialCount);
+  expect(failedOnce).toBeTruthy();
+
+  const cleanup = await page.request.post('/api/items/delete', { data: { id } });
+  expect(cleanup.ok()).toBeTruthy();
+});
+
 test('hide/unhide preserves stale state', async ({ page }) => {
   const title = `hide-stale-${Date.now()}`;
   const created = await createCard(page, title);

--- a/static/app.js
+++ b/static/app.js
@@ -810,21 +810,29 @@
     }, 180));
   }
 
-  function hidePinImmediate(pin){
+  async function hidePinImmediate(pin){
+    if (pin.dataset.hidePending === 'true') return;
     cancelPendingSave(pin.dataset.id);
-    fetch('/api/items/hide', {
-      method:'POST',
-      headers:{'Content-Type':'application/json'},
-      body:JSON.stringify({id: pin.dataset.id, contextId: currentContextId})
-    }).then(async (r) => {
-      const d = await r.json();
-      hiddenCount = d.hiddenCount || (hiddenCount + 1);
+    pin.dataset.hidePending = 'true';
+    try {
+      const r = await fetch('/api/items/hide', {
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({id: pin.dataset.id, contextId: currentContextId})
+      });
+      if (!r.ok) throw new Error(`hide failed (${r.status})`);
+      const d = await r.json().catch(() => null);
+      hiddenCount = (d && Number.isFinite(Number(d.hiddenCount))) ? Number(d.hiddenCount) : (hiddenCount + 1);
       renderHiddenButton();
       if (trayOpen) openHiddenTray();
-    });
-    lensExempt.delete(pin.dataset.id);
-    if (activePin === pin) setActivePin(null);
-    pin.remove();
+      lensExempt.delete(pin.dataset.id);
+      if (activePin === pin) setActivePin(null);
+      pin.remove();
+      return;
+    } catch (_err) {
+      showCanvasWarning('Unable to hide card. Please try again.');
+    }
+    pin.dataset.hidePending = 'false';
   }
 
   async function deletePinImmediate(pin){


### PR DESCRIPTION
## Summary
- Convert hide flow to ACK-gated behavior.
- Prevent destructive UI removal before hide API success.
- Add explicit hide failure warning path.
- Add regression test for hide API failure (card remains visible; hidden count unchanged).

## Files
- `static/app.js`
- `e2e/core-ui.spec.ts`

## Verification
- `npm run test:ui -- --grep "hide failure keeps card visible and shows warning|hide/unhide updates hidden tray count accurately|hide/unhide preserves stale state"`
