### PR TITLE
fix(ui): gate delete-undo restore on server ack (#16)

### DIFF
--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -1298,6 +1298,34 @@ test('delete in focus uses undo without confirmation modal', async ({ page }) =>
   await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(1);
 });
 
+test('delete undo waits for persistence before restoring card', async ({ page }) => {
+  const title = `delete-undo-fail-${Date.now()}`;
+  const created = await createCard(page, title, 1160, 320);
+  const id = await created.getAttribute('data-id');
+  expect(id).toBeTruthy();
+
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-delete').click();
+  await expect(page.locator('.undo-toast')).toContainText('Deleted');
+  await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(0);
+
+  let failedUndoOnce = false;
+  await page.route('**/api/items', async (route, request) => {
+    if (!failedUndoOnce && request.method() === 'POST') {
+      failedUndoOnce = true;
+      await route.fulfill({ status: 500, body: 'restore failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.locator('.undo-btn').click();
+  await expect(page.locator('.canvas-warning')).toContainText(/Unable to restore deleted card\.|restore failed/);
+  await expect(page.locator('.undo-toast')).toHaveCount(0);
+  await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(0);
+  expect(failedUndoOnce).toBeTruthy();
+});
+
 test('context delete requires confirmation and cancel keeps context', async ({ page }) => {
   await page.goto('/?canvas=contexts');
   await expect(page.locator('#surface')).toBeVisible();

--- a/static/app.js
+++ b/static/app.js
@@ -934,13 +934,24 @@
     };
   }
   function showDeleteUndo(payload){
-    showUndoToast('Deleted', 'delete', payload.id, () => {
+    showUndoToast('Deleted', 'delete', payload.id, async () => {
+      let res;
+      try {
+        res = await fetch(mode === 'focus' ? '/api/items' : '/api/contexts', {
+          method:'POST',
+          headers:{'Content-Type':'application/json'},
+          body:JSON.stringify(payload)
+        });
+      } catch (_err) {
+        showCanvasWarning(mode === 'focus' ? 'Unable to restore deleted card. Please try again.' : 'Unable to restore deleted context. Please try again.');
+        return false;
+      }
+      if (!res.ok) {
+        const message = await res.text().catch(() => '');
+        showCanvasWarning(message || (mode === 'focus' ? 'Unable to restore deleted card.' : 'Unable to restore deleted context.'));
+        return false;
+      }
       createPin(payload, false, true);
-      fetch(mode === 'focus' ? '/api/items' : '/api/contexts', {
-        method:'POST',
-        headers:{'Content-Type':'application/json'},
-        body:JSON.stringify(payload)
-      });
       return true;
     });
   }


### PR DESCRIPTION
## Summary
- Make delete-undo restore ACK-gated instead of fire-and-forget.
- Undo now reports success only after restore persistence succeeds.
- Add explicit restore-failure warning and deterministic no-restore outcome.
- Add regression coverage for restore failure path.

## Files
- `static/app.js`
- `e2e/core-ui.spec.ts`

## Verification
- `npm run test:ui -- --grep "delete in focus uses undo without confirmation modal|delete undo waits for persistence before restoring card"`
