### PR TITLE
fix(ui): structured mutation failure diagnostics across mutation paths (#17)

### DIFF
--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
-import { expect, test, type Page, type Locator } from '@playwright/test';
+import { expect, test, type Page, type Locator, type ConsoleMessage } from '@playwright/test';
 
 async function createCard(page: Page, title: string, x = 1050, y = 620): Promise<Locator> {
   const pins = page.locator('.pin');
@@ -198,6 +198,25 @@ function ageCardInDb(id: string, daysAgo: number): void {
   const when = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString();
   const sql = `UPDATE items SET created_at=${sqlLiteral(when)} WHERE id=${sqlLiteral(id)};`;
   execFileSync('sqlite3', [sqliteDbPath(), sql], { stdio: 'pipe' });
+}
+
+function collectMutationFailureLogs(page: Page): { logs: string[]; stop: () => void } {
+  const logs: string[] = [];
+  const onConsole = (msg: ConsoleMessage): void => {
+    if (msg.type() !== 'error') return;
+    const text = msg.text();
+    if (!text.includes('[mutation-failure]')) return;
+    logs.push(text);
+  };
+  page.on('console', onConsole);
+  return {
+    logs,
+    stop: () => page.off('console', onConsole),
+  };
+}
+
+function hasMutationLog(logs: string[], operation: string, endpoint: string): boolean {
+  return logs.some((line) => line.includes(`"operation":"${operation}"`) && line.includes(`"endpoint":"${endpoint}"`));
 }
 
 test.beforeEach(async ({ page }) => {
@@ -1324,6 +1343,167 @@ test('delete undo waits for persistence before restoring card', async ({ page })
   await expect(page.locator('.undo-toast')).toHaveCount(0);
   await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(0);
   expect(failedUndoOnce).toBeTruthy();
+});
+
+test('mutation failure logs include structured context for context-title and pin save', async ({ page }) => {
+  const collected = collectMutationFailureLogs(page);
+
+  let contextSaveFailed = false;
+  await page.route('**/api/contexts', async (route, request) => {
+    if (!contextSaveFailed && request.method() === 'POST') {
+      contextSaveFailed = true;
+      await route.fulfill({ status: 500, body: 'context save failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  const contextName = page.locator('#context-name');
+  await contextName.focus();
+  await contextName.evaluate((el, value) => {
+    el.textContent = String(value);
+    (el as HTMLElement).blur();
+  }, `ctx-log-${Date.now()}`);
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to save context title');
+
+  let saveFailed = false;
+  await page.route('**/api/items', async (route, request) => {
+    if (!saveFailed && request.method() === 'POST') {
+      saveFailed = true;
+      await route.fulfill({ status: 500, body: 'item save failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  const pin = page.locator('.pin').first();
+  await pin.locator('.pin-title input').fill(`save-log-${Date.now()}`);
+  await pin.locator('.pin-title input').blur();
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to save card changes');
+
+  expect(hasMutationLog(collected.logs, 'context-title-save', '/api/contexts')).toBeTruthy();
+  expect(hasMutationLog(collected.logs, 'save-pin', '/api/items')).toBeTruthy();
+  collected.stop();
+});
+
+test('mutation failure logs include structured context for hide failures', async ({ page }) => {
+  const collected = collectMutationFailureLogs(page);
+  const created = await createCard(page, `hide-log-${Date.now()}`);
+  let failedOnce = false;
+
+  await page.route('**/api/items/hide', async (route, request) => {
+    if (!failedOnce && request.method() === 'POST') {
+      failedOnce = true;
+      await route.fulfill({ status: 500, body: 'hide failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await ensureFiltersTrayOpen(page);
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-hide').click();
+  await expect(page.locator('.canvas-warning')).toContainText('Unable to hide card');
+  expect(failedOnce).toBeTruthy();
+  expect(hasMutationLog(collected.logs, 'hide-pin', '/api/items/hide')).toBeTruthy();
+  collected.stop();
+});
+
+test('mutation failure logs include structured context for delete failures', async ({ page }) => {
+  const collected = collectMutationFailureLogs(page);
+  const created = await createCard(page, `delete-log-${Date.now()}`);
+  const id = await created.getAttribute('data-id');
+  expect(id).toBeTruthy();
+  let failedOnce = false;
+
+  await page.route('**/api/items/delete', async (route, request) => {
+    if (!failedOnce && request.method() === 'POST') {
+      failedOnce = true;
+      await route.abort('failed');
+      return;
+    }
+    await route.continue();
+  });
+
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-delete').click();
+  await expect(page.locator(`.pin[data-id="${id}"]`)).toHaveCount(1);
+  expect(failedOnce).toBeTruthy();
+  await expect.poll(() => collected.logs.length).toBeGreaterThan(0);
+  const deleteLogText = collected.logs.join('\n');
+  expect(deleteLogText).toContain('"operation":"delete-pin"');
+  expect(deleteLogText).toContain('/api/items/delete');
+  collected.stop();
+});
+
+test('mutation failure logs include structured context for touch and complete failures', async ({ page }) => {
+  const collected = collectMutationFailureLogs(page);
+  const created = await createCard(page, `touch-complete-log-${Date.now()}`);
+
+  let touchFailed = false;
+  await page.route('**/api/items/touch', async (route, request) => {
+    if (!touchFailed && request.method() === 'POST') {
+      touchFailed = true;
+      await route.fulfill({ status: 500, body: 'touch failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await created.locator('.pin-touch').click();
+  await expect(page.locator('.canvas-warning')).toContainText(/Unable to touch card\.|touch failed/);
+
+  let completeFailed = false;
+  await page.route('**/api/items/complete', async (route, request) => {
+    if (!completeFailed && request.method() === 'POST') {
+      completeFailed = true;
+      await route.fulfill({ status: 500, body: 'complete failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-complete').click();
+  await expect(page.locator('.canvas-warning')).toContainText(/Unable to complete card\.|complete failed/);
+
+  expect(touchFailed).toBeTruthy();
+  expect(completeFailed).toBeTruthy();
+  expect(hasMutationLog(collected.logs, 'touch-pin', '/api/items/touch')).toBeTruthy();
+  expect(hasMutationLog(collected.logs, 'complete-pin', '/api/items/complete')).toBeTruthy();
+  collected.stop();
+});
+
+test('mutation failure logs include structured context for unhide failures', async ({ page }) => {
+  const collected = collectMutationFailureLogs(page);
+  const title = `unhide-log-${Date.now()}`;
+  const created = await createCard(page, title);
+
+  await ensureFiltersTrayOpen(page);
+  await openActionDrawer(created);
+  await created.locator('.pin-action-drawer .pin-hide').click();
+  await expect.poll(() => getHiddenCount(page)).toBeGreaterThan(0);
+
+  let unhideFailed = false;
+  await page.route('**/api/items/unhide-at', async (route, request) => {
+    if (!unhideFailed && request.method() === 'POST') {
+      unhideFailed = true;
+      await route.fulfill({ status: 500, body: 'unhide failed' });
+      return;
+    }
+    await route.continue();
+  });
+
+  const hiddenToggle = page.locator('#hidden-toggle');
+  await hiddenToggle.click();
+  const hiddenItem = page.locator('.hidden-tray-item', { hasText: title }).first();
+  await expect(hiddenItem).toBeVisible();
+  await hiddenItem.dragTo(page.locator('#surface'), { targetPosition: { x: 360, y: 300 } });
+
+  await expect(page.locator('.canvas-warning')).toContainText(/unhide item|unhide failed/i);
+  expect(unhideFailed).toBeTruthy();
+  expect(hasMutationLog(collected.logs, 'unhide-at', '/api/items/unhide-at')).toBeTruthy();
+  collected.stop();
 });
 
 test('context delete requires confirmation and cancel keeps context', async ({ page }) => {

--- a/static/app.js
+++ b/static/app.js
@@ -94,6 +94,7 @@
     const previousTitle = contextTitlePersisted;
     if (nextTitle === previousTitle) return;
     const saveSeq = ++contextTitleSaveSeq;
+    let status = null;
     try {
       const res = await fetch('/api/contexts', {
         method:'POST',
@@ -101,10 +102,22 @@
         body:JSON.stringify({id: currentContextId, title: nextTitle})
       });
       if (saveSeq !== contextTitleSaveSeq) return;
-      if (!res.ok) throw new Error(`context title save failed (${res.status})`);
+      status = res.status;
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        throw new Error(detail || `context title save failed (${res.status})`);
+      }
       contextTitlePersisted = nextTitle;
     } catch (_err) {
       if (saveSeq !== contextTitleSaveSeq) return;
+      logMutationFailure({
+        operation: 'context-title-save',
+        id: currentContextId,
+        contextId: currentContextId,
+        endpoint: '/api/contexts',
+        status,
+        error: mutationErrorSummary(_err),
+      });
       contextNameEl.textContent = previousTitle;
       showCanvasWarning('Unable to save context title. Restored previous value.');
     }
@@ -256,6 +269,28 @@
       token: '!',
       durationMs: 2800,
     });
+  }
+
+  function mutationErrorSummary(err){
+    if (err instanceof Error) return err.message;
+    if (typeof err === 'string') return err;
+    try {
+      return JSON.stringify(err);
+    } catch (_jsonErr) {
+      return String(err);
+    }
+  }
+
+  function logMutationFailure({ operation, id, contextId, endpoint, status, error }){
+    const payload = {
+      operation: operation || '',
+      id: id || '',
+      contextId: contextId || '',
+      endpoint: endpoint || '',
+      status: Number.isFinite(status) ? Number(status) : null,
+      error: error || '',
+    };
+    console.error('[mutation-failure]', JSON.stringify(payload));
   }
 
   function setSystemAckMode(mode){
@@ -785,18 +820,24 @@
     if (pin.dataset.state === 'completed' || pin.dataset.transitioning === 'true') return;
     const id = pin.dataset.id;
     const payload = pinPayload(pin);
+    const endpoint = mode === 'focus' ? '/api/items' : '/api/contexts';
     cancelPendingSave(id);
     pending.set(id, setTimeout(async () => {
       const saveSeq = (saveRequestSeq.get(id) || 0) + 1;
       saveRequestSeq.set(id, saveSeq);
+      let status = null;
       try {
-        const res = await fetch(mode === 'focus' ? '/api/items' : '/api/contexts', {
+        const res = await fetch(endpoint, {
           method:'POST',
           headers:{'Content-Type':'application/json'},
           body:JSON.stringify(payload)
         });
         if (saveRequestSeq.get(id) !== saveSeq) return;
-        if (!res.ok) throw new Error(`save failed (${res.status})`);
+        status = res.status;
+        if (!res.ok) {
+          const detail = await res.text().catch(() => '');
+          throw new Error(detail || `save failed (${res.status})`);
+        }
         const data = await res.json().catch(() => null);
         if (saveRequestSeq.get(id) !== saveSeq) return;
         if (data) applyTouchResponse(pin, data);
@@ -804,6 +845,14 @@
         markPersisted(pin);
       } catch (_err) {
         if (saveRequestSeq.get(id) !== saveSeq) return;
+        logMutationFailure({
+          operation: mode === 'focus' ? 'save-pin' : 'save-context-card',
+          id,
+          contextId: currentContextId,
+          endpoint,
+          status,
+          error: mutationErrorSummary(_err),
+        });
         pin.dataset.saved = 'false';
         showCanvasWarning(mode === 'focus' ? 'Unable to save card changes. Your edits are kept locally.' : 'Unable to save context changes. Your edits are kept locally.');
       }
@@ -814,13 +863,18 @@
     if (pin.dataset.hidePending === 'true') return;
     cancelPendingSave(pin.dataset.id);
     pin.dataset.hidePending = 'true';
+    let status = null;
     try {
       const r = await fetch('/api/items/hide', {
         method:'POST',
         headers:{'Content-Type':'application/json'},
         body:JSON.stringify({id: pin.dataset.id, contextId: currentContextId})
       });
-      if (!r.ok) throw new Error(`hide failed (${r.status})`);
+      status = r.status;
+      if (!r.ok) {
+        const detail = await r.text().catch(() => '');
+        throw new Error(detail || `hide failed (${r.status})`);
+      }
       const d = await r.json().catch(() => null);
       hiddenCount = (d && Number.isFinite(Number(d.hiddenCount))) ? Number(d.hiddenCount) : (hiddenCount + 1);
       renderHiddenButton();
@@ -830,6 +884,14 @@
       pin.remove();
       return;
     } catch (_err) {
+      logMutationFailure({
+        operation: 'hide-pin',
+        id: pin.dataset.id,
+        contextId: currentContextId,
+        endpoint: '/api/items/hide',
+        status,
+        error: mutationErrorSummary(_err),
+      });
       showCanvasWarning('Unable to hide card. Please try again.');
     }
     pin.dataset.hidePending = 'false';
@@ -838,6 +900,7 @@
   async function deletePinImmediate(pin){
     if (pin.dataset.transitioning === 'true' || pin.dataset.state === 'completed') return;
     const payload = pinPayload(pin);
+    const endpoint = mode === 'focus' ? '/api/items/delete' : '/api/contexts/delete';
 
     if (mode === 'contexts') {
       const ok = await confirmContextDelete(payload.title);
@@ -848,13 +911,23 @@
     cancelPendingSave(payload.id);
 
     let res;
+    let status = null;
     try {
-      res = await fetch(mode === 'focus' ? '/api/items/delete' : '/api/contexts/delete', {
+      res = await fetch(endpoint, {
         method:'POST',
         headers:{'Content-Type':'application/json'},
         body:JSON.stringify({id: payload.id})
       });
+      status = res.status;
     } catch (_err) {
+      logMutationFailure({
+        operation: mode === 'focus' ? 'delete-pin' : 'delete-context',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint,
+        status,
+        error: mutationErrorSummary(_err),
+      });
       if (mode === 'contexts') {
         showCanvasWarning('Unable to delete context. Please try again.');
       }
@@ -868,15 +941,39 @@
           res = retry;
         } else {
           const message = await retry.text();
+          logMutationFailure({
+            operation: 'delete-context',
+            id: payload.id,
+            contextId: currentContextId,
+            endpoint: '/api/contexts/delete?id=...',
+            status: retry.status,
+            error: message || `delete context failed (${retry.status})`,
+          });
           showCanvasWarning(message || 'Unable to delete context');
           return;
         }
       } catch (_err) {
+        logMutationFailure({
+          operation: 'delete-context',
+          id: payload.id,
+          contextId: currentContextId,
+          endpoint: '/api/contexts/delete?id=...',
+          status: null,
+          error: mutationErrorSummary(_err),
+        });
         showCanvasWarning('Unable to delete context. Please try again.');
         return;
       }
     } else if (!res.ok) {
       const message = await res.text();
+      logMutationFailure({
+        operation: mode === 'focus' ? 'delete-pin' : 'delete-context',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint,
+        status,
+        error: message || `delete failed (${status})`,
+      });
       if (mode === 'contexts') {
         showCanvasWarning(message || 'Unable to delete context');
       }
@@ -1030,6 +1127,7 @@
     if (mode !== 'focus' || pin.dataset.saved !== 'true') return;
     if (pin.dataset.state === 'completed' || pin.dataset.transitioning === 'true') return;
     const payload = pinPayload(pin);
+    let status = null;
     let res;
     try {
       res = await fetch('/api/items/touch', {
@@ -1037,12 +1135,29 @@
         headers:{'Content-Type':'application/json'},
         body:JSON.stringify({id: payload.id})
       });
+      status = res.status;
     } catch (_err) {
+      logMutationFailure({
+        operation: 'touch-pin',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint: '/api/items/touch',
+        status,
+        error: mutationErrorSummary(_err),
+      });
       showCanvasWarning('Unable to touch card. Please try again.');
       return;
     }
     if (!res.ok) {
       const message = await res.text();
+      logMutationFailure({
+        operation: 'touch-pin',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint: '/api/items/touch',
+        status,
+        error: message || `touch failed (${status})`,
+      });
       showCanvasWarning(message || 'Unable to touch card.');
       return;
     }
@@ -1057,6 +1172,7 @@
     const payload = pinPayload(pin);
     pin.dataset.transitioning = 'true';
     cancelPendingSave(payload.id);
+    let status = null;
     let res;
     try {
       res = await fetch('/api/items/complete', {
@@ -1064,7 +1180,16 @@
         headers:{'Content-Type':'application/json'},
         body:JSON.stringify({id: payload.id, completed: true})
       });
+      status = res.status;
     } catch (_err) {
+      logMutationFailure({
+        operation: 'complete-pin',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint: '/api/items/complete',
+        status,
+        error: mutationErrorSummary(_err),
+      });
       pin.dataset.transitioning = 'false';
       showCanvasWarning('Unable to complete card. Please try again.');
       return;
@@ -1072,6 +1197,14 @@
     if (!res.ok) {
       pin.dataset.transitioning = 'false';
       const message = await res.text();
+      logMutationFailure({
+        operation: 'complete-pin',
+        id: payload.id,
+        contextId: currentContextId,
+        endpoint: '/api/items/complete',
+        status,
+        error: message || `complete failed (${status})`,
+      });
       showCanvasWarning(message || 'Unable to complete card.');
       return;
     }
@@ -1396,9 +1529,14 @@
     renderHiddenButton();
     syncHiddenTray();
     const persist = async () => {
+      let status = null;
       try {
         const res = await fetch('/api/items/unhide-at', {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({id, contextId: currentContextId, x, y})});
-        if (!res.ok) throw new Error('unhide failed');
+        status = res.status;
+        if (!res.ok) {
+          const detail = await res.text().catch(() => '');
+          throw new Error(detail || `unhide failed (${res.status})`);
+        }
         const data = await res.json().catch(() => null);
         const pending = pendingUnhide.get(id);
         if (!pending) return;
@@ -1407,6 +1545,14 @@
         if (!surface.querySelector(`.pin[data-id="${id}"]`)) createPin(restoredItem, false, true);
         showResurfaceAck();
       } catch (_err) {
+        logMutationFailure({
+          operation: 'unhide-at',
+          id,
+          contextId: currentContextId,
+          endpoint: '/api/items/unhide-at',
+          status,
+          error: mutationErrorSummary(_err),
+        });
         const pending = pendingUnhide.get(id);
         if (!pending) return;
         pendingUnhide.delete(id);


### PR DESCRIPTION
## Summary
- Added structured mutation-failure logging contract in client runtime:
  - operation
  - id
  - contextId
  - endpoint
  - status
  - error
- Applied contract to failure paths for:
  - context-title save
  - card/context save (`savePin`)
  - hide
  - delete
  - touch
  - complete
  - unhide-at
- Added Playwright regressions that assert structured logs are emitted for each representative mutation family.

## Files
- `static/app.js`
- `e2e/core-ui.spec.ts`

## Verification
- `npm run test:ui -- --grep "mutation failure logs include structured context"`
- `npm run test:ui -- --grep "context title save failure|card save failure|hide failure keeps card visible and shows warning|delete undo waits for persistence before restoring card|mutation failure logs include structured context"`
