### PR TITLE
test: lock high-signal app.js regression baseline (#70)

### DIFF
--- a/appjs_regression_lock_architecture_test.go
+++ b/appjs_regression_lock_architecture_test.go
@@ -1,0 +1,43 @@
+package orbit
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppJSSimplificationRegressionLockRED(t *testing.T) {
+	specPath := filepath.Join("e2e", "core-ui.spec.ts")
+	specBytes, err := os.ReadFile(specPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", specPath, err)
+	}
+	spec := string(specBytes)
+
+	requiredRegressions := []string{
+		"blank context cards are discarded when left empty",
+		"card note height increases from one line to two lines",
+		"touch control stays explicit, toggles today state, and supports undo",
+		"complete shows acknowledgment, supports undo, and expires after 6s",
+		"hide/unhide updates hidden tray count accurately",
+		"drag/drop persists card position after reload",
+		"center/periphery lens keeps canonical membership while slider only moves the cue",
+		"mutation failure logs include structured context for context-title and pin save",
+	}
+
+	for _, name := range requiredRegressions {
+		t.Run(name, func(t *testing.T) {
+			testDecl := "test('" + name + "'"
+			if !strings.Contains(spec, testDecl) {
+				t.Fatalf("required regression test missing from %s: %q", specPath, name)
+			}
+			if strings.Contains(spec, "test.skip('"+name+"'") {
+				t.Fatalf("required regression test is skipped in %s: %q", specPath, name)
+			}
+			if strings.Contains(spec, "test.fixme('"+name+"'") {
+				t.Fatalf("required regression test is marked fixme in %s: %q", specPath, name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add pre-refactor regression-lock architecture test for app.js simplification
- lock required high-signal UX regression test names in e2e/core-ui.spec.ts
- fail if any required regression is removed, skipped, or marked fixme

## Linked issue
- Closes #70

## Verify
- go test . -run '^TestAppJSSimplificationRegressionLockRED$'
- node --check static/app.js
- npm run test:ui -- -g "blank context cards are discarded when left empty|card note height increases from one line to two lines|touch control stays explicit, toggles today state, and supports undo|complete shows acknowledgment, supports undo, and expires after 6s|hide/unhide updates hidden tray count accurately|drag/drop persists card position after reload|center/periphery lens keeps canonical membership while slider only moves the cue|mutation failure logs include structured context for context-title and pin save"
- golangci-lint run .
