### PR TITLE
Resolve #75: narrow post-extraction runtime contracts

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -243,45 +243,49 @@ void (async () => {
     setActivePin,
     applyTouchResponse,
   });
-  const pinDestructiveController = createPinDestructiveController({
+  const pinMutationRuntime = {
     mode,
     currentContextId,
     getTransport: getMutationTransport,
     readPinPayload: pinPayload,
     cancelPendingSave,
     showCanvasWarning,
-    confirmContextDelete,
-    handleHideSuccess(data, pin) {
-      hiddenTrayState.handleHideSuccess(data);
-      lensState.forgetPin(pin.dataset.id);
-      if (activePin === pin) setActivePin(null);
-      pin.remove();
-    },
-    handleDeleteSuccess(pin, payload) {
-      lensState.forgetPin(pin.dataset.id);
-      if (activePin === pin) setActivePin(null);
-      pin.remove();
-      if (mode === 'contexts') {
-        location.reload();
-        return;
-      }
-      if (mode === 'focus') undoAckController.showDeleteUndo(payload);
-    },
-    handleDiscardRemove(pin) {
-      if (activePin === pin) setActivePin(null);
-      pin.remove();
+  };
+  const pinDestructiveController = createPinDestructiveController({
+    runtime: pinMutationRuntime,
+    effects: {
+      confirmContextDelete,
+      handleHideSuccess(data, pin) {
+        hiddenTrayState.handleHideSuccess(data);
+        lensState.forgetPin(pin.dataset.id);
+        if (activePin === pin) setActivePin(null);
+        pin.remove();
+      },
+      handleDeleteSuccess(pin, payload) {
+        lensState.forgetPin(pin.dataset.id);
+        if (activePin === pin) setActivePin(null);
+        pin.remove();
+        if (mode === 'contexts') {
+          location.reload();
+          return;
+        }
+        if (mode === 'focus') undoAckController.showDeleteUndo(payload);
+      },
+      handleDiscardRemove(pin) {
+        if (activePin === pin) setActivePin(null);
+        pin.remove();
+      },
     },
   });
   const pinTouchCompleteController = createPinTouchCompleteController({
-    mode,
-    currentContextId,
-    getTransport: getMutationTransport,
-    readPinPayload: pinPayload,
-    cancelPendingSave,
-    applyTouchResponse,
-    showCanvasWarning,
-    showTouchUndo: undoAckController.showTouchUndo,
-    handleCompleteSuccess: undoAckController.handleCompleteSuccess,
+    runtime: pinMutationRuntime,
+    touchEffects: {
+      applyTouchResponse,
+      showTouchUndo: undoAckController.showTouchUndo,
+    },
+    completeEffects: {
+      handleCompleteSuccess: undoAckController.handleCompleteSuccess,
+    },
   });
 
   const pinDomController = createPinDomController({

--- a/static/pin_destructive.js
+++ b/static/pin_destructive.js
@@ -1,15 +1,19 @@
-export function createPinDestructiveController({
-  mode,
-  currentContextId,
-  getTransport,
-  readPinPayload,
-  cancelPendingSave,
-  showCanvasWarning,
-  confirmContextDelete,
-  handleHideSuccess,
-  handleDeleteSuccess,
-  handleDiscardRemove,
-}) {
+export function createPinDestructiveController({runtime, effects}) {
+  const {
+    mode,
+    currentContextId,
+    getTransport,
+    readPinPayload,
+    cancelPendingSave,
+    showCanvasWarning,
+  } = runtime;
+  const {
+    confirmContextDelete,
+    handleHideSuccess,
+    handleDeleteSuccess,
+    handleDiscardRemove,
+  } = effects;
+
   async function hidePinImmediate(pin) {
     if (pin.dataset.hidePending === 'true') return;
     cancelPendingSave(pin.dataset.id);

--- a/static/pin_touch_complete.js
+++ b/static/pin_touch_complete.js
@@ -1,14 +1,19 @@
 export function createPinTouchCompleteController({
-  mode,
-  currentContextId,
-  getTransport,
-  readPinPayload,
-  cancelPendingSave,
-  applyTouchResponse,
-  showCanvasWarning,
-  showTouchUndo,
-  handleCompleteSuccess,
+  runtime,
+  touchEffects,
+  completeEffects,
 }) {
+  const {
+    mode,
+    currentContextId,
+    getTransport,
+    readPinPayload,
+    cancelPendingSave,
+    showCanvasWarning,
+  } = runtime;
+  const {applyTouchResponse, showTouchUndo} = touchEffects;
+  const {handleCompleteSuccess} = completeEffects;
+
   async function touchPinImmediate(pin) {
     if (mode !== 'focus' || pin.dataset.saved !== 'true') return;
     if (pin.dataset.state === 'completed' || pin.dataset.transitioning === 'true') return;


### PR DESCRIPTION
## Summary
- group touch/complete and destructive runtime dependencies into focused runtime/effects objects
- keep `app.js` as composition wiring while making module contracts smaller and more explicit
- preserve existing drag/drop, hide, touch, and complete behavior with narrower constructor surfaces

## Verification
- `node --check static/app.js`
- `go test . -run 'TestAppJsCompositionGuardrails|TestFrontendSplitPhase2ArchitectureRED|TestAppJSSimplificationRegressionLockRED'`
- `npm run test:ui -- -g "drag/drop persists card position after reload|hide/unhide updates hidden tray count accurately|touch control stays explicit, toggles today state, and supports undo|complete shows acknowledgment, supports undo, and expires after 6s"`
