### PR TITLE
Resolve #76: harden app.js anti-drift guardrails

### DIFF
--- a/app_js_architecture_test.go
+++ b/app_js_architecture_test.go
@@ -15,23 +15,82 @@ func TestAppJsCompositionGuardrails(t *testing.T) {
 	}
 	body := string(bodyBytes)
 
-	t.Run("app.js imports extracted pin presenter", func(t *testing.T) {
-		if !strings.Contains(body, "import('/static/pin_presenter.js')") {
-			t.Fatalf("app.js must compose the extracted pin presenter module")
+	t.Run("app.js imports extracted interaction modules", func(t *testing.T) {
+		requiredImports := []string{
+			"import('/static/pin_presenter.js')",
+			"import('/static/pin_touch_complete.js')",
+			"import('/static/pin_destructive.js')",
+		}
+		for _, snippet := range requiredImports {
+			if !strings.Contains(body, snippet) {
+				t.Fatalf("app.js must compose extracted runtime modules (%q)", snippet)
+			}
 		}
 	})
 
-	t.Run("app.js no longer owns pin presentation internals", func(t *testing.T) {
+	t.Run("app.js no longer owns extracted interaction internals", func(t *testing.T) {
 		disallowed := []string{
 			"function resolveCssColorToRgb(",
 			"function deriveTouchColors(",
 			"function syncTouchState(",
 			"function applyTouchResponse(",
 			"pin.style.setProperty('--pin-touch-accent-rgb'",
+			"async function touchPinImmediate(",
+			"async function completePinImmediate(",
+			"async function hidePinImmediate(",
+			"async function deletePinImmediate(",
+			"function discardIfEmpty(",
+			"transport.touchItem({id: payload.id})",
+			"transport.setItemCompleted({id: payload.id, completed: true})",
+			"transport.hideItem({id: pin.dataset.id, contextId: currentContextId})",
+			"transport.deleteEntity({mode, id: payload.id})",
+			"transport.deleteEntityFireAndForget({mode, id: pin.dataset.id, contextId: currentContextId})",
 		}
 		for _, snippet := range disallowed {
 			if strings.Contains(body, snippet) {
-				t.Fatalf("app.js still owns pin presentation concern internals (%q); keep them in extracted runtime modules", snippet)
+				t.Fatalf("app.js still owns extracted interaction concern internals (%q); keep them in extracted runtime modules", snippet)
+			}
+		}
+	})
+
+	t.Run("extracted interaction modules own their controller signatures", func(t *testing.T) {
+		requiredModules := []struct {
+			path     string
+			snippets []string
+		}{
+			{
+				path: filepath.Join("static", "pin_touch_complete.js"),
+				snippets: []string{
+					"export function createPinTouchCompleteController(",
+					"touchPinImmediate",
+					"completePinImmediate",
+					"transport.touchItem({id: payload.id})",
+					"transport.setItemCompleted({id: payload.id, completed: true})",
+				},
+			},
+			{
+				path: filepath.Join("static", "pin_destructive.js"),
+				snippets: []string{
+					"export function createPinDestructiveController(",
+					"hidePinImmediate",
+					"deletePinImmediate",
+					"discardIfEmpty",
+					"transport.hideItem({id: pin.dataset.id, contextId: currentContextId})",
+					"transport.deleteEntity({mode, id: payload.id})",
+					"transport.deleteEntityFireAndForget({mode, id: pin.dataset.id, contextId: currentContextId})",
+				},
+			},
+		}
+		for _, module := range requiredModules {
+			moduleBytes, err := os.ReadFile(module.path)
+			if err != nil {
+				t.Fatalf("read %s: %v", module.path, err)
+			}
+			moduleBody := string(moduleBytes)
+			for _, snippet := range module.snippets {
+				if !strings.Contains(moduleBody, snippet) {
+					t.Fatalf("%s must own extracted interaction snippet %q", module.path, snippet)
+				}
 			}
 		}
 	})


### PR DESCRIPTION
## Summary
- expand the app.js architecture guardrails to cover the extracted touch/complete and destructive interaction ownership
- assert that the extracted interaction modules, not `app.js`, own the relevant controller signatures and transport calls
- keep the existing thin-shell line-budget guard active

## Verification
- `go test . -run 'TestAppJsCompositionGuardrails|TestFrontendSplitPhase2ArchitectureRED|TestMutationTransportArchitectureRED|TestAppJSSimplificationRegressionLockRED'`
- `node --check static/app.js`
- `npm run test:ui -- -g "blank context cards are discarded when left empty|touch control stays explicit, toggles today state, and supports undo|complete shows acknowledgment, supports undo, and expires after 6s|hide/unhide updates hidden tray count accurately"`
