### PR TITLE
Hidden tray: mark expired snoozes as Resurfaced

### DIFF
--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -1188,25 +1188,29 @@ test('hidden tray shows snooze days-left only for snoozed cards', async ({ page 
   await expect(skippedHiddenItem.locator('.hidden-tray-item__snooze')).toHaveCount(0);
 });
 
-test('hidden tray shows hour labels under one day and day labels from one day onward', async ({ page }) => {
+test('hidden tray shows countdown for future snoozes and Resurfaced badge for expired snoozes', async ({ page }) => {
   const fiveHoursTitle = `hidden-5h-${Date.now()}`;
   const dayBoundaryTitle = `hidden-24h-${Date.now()}`;
   const twoDaysTitle = `hidden-2d-${Date.now()}`;
   const expiredTitle = `hidden-expired-${Date.now()}`;
+  const unsnoozedTitle = `hidden-unsnoozed-${Date.now()}`;
   const fiveHoursCard = await createCard(page, fiveHoursTitle);
   const dayBoundaryCard = await createCard(page, dayBoundaryTitle);
   const twoDaysCard = await createCard(page, twoDaysTitle);
   const expiredCard = await createCard(page, expiredTitle);
+  const unsnoozedCard = await createCard(page, unsnoozedTitle);
   const fiveHoursID = await fiveHoursCard.getAttribute('data-id');
   const dayBoundaryID = await dayBoundaryCard.getAttribute('data-id');
   const twoDaysID = await twoDaysCard.getAttribute('data-id');
   const expiredID = await expiredCard.getAttribute('data-id');
+  const unsnoozedID = await unsnoozedCard.getAttribute('data-id');
   expect(fiveHoursID).toBeTruthy();
   expect(dayBoundaryID).toBeTruthy();
   expect(twoDaysID).toBeTruthy();
   expect(expiredID).toBeTruthy();
+  expect(unsnoozedID).toBeTruthy();
 
-  const hideResults = await page.evaluate(async ({ fiveHoursCardID, dayBoundaryCardID, twoDaysCardID, expiredCardID }) => {
+  const hideResults = await page.evaluate(async ({ fiveHoursCardID, dayBoundaryCardID, twoDaysCardID, expiredCardID, unsnoozedCardID }) => {
     const now = Date.now();
     const fiveHours = new Date(now + ((4 * 60 + 20) * 60 * 1000)).toISOString();
     const nearDayBoundary = new Date(now + ((23 * 60 + 10) * 60 * 1000)).toISOString();
@@ -1225,17 +1229,24 @@ test('hidden tray shows hour labels under one day and day labels from one day on
       dayBoundaryOk: await postHide(dayBoundaryCardID, nearDayBoundary),
       twoDaysOk: await postHide(twoDaysCardID, justOverDay),
       expiredOk: await postHide(expiredCardID, expired),
+      unsnoozedOk: (await fetch('/api/items/hide', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: unsnoozedCardID, contextId: 'main-orbit' }),
+      })).ok,
     };
   }, {
     fiveHoursCardID: fiveHoursID,
     dayBoundaryCardID: dayBoundaryID,
     twoDaysCardID: twoDaysID,
     expiredCardID: expiredID,
+    unsnoozedCardID: unsnoozedID,
   });
   expect(hideResults.fiveHoursOk).toBeTruthy();
   expect(hideResults.dayBoundaryOk).toBeTruthy();
   expect(hideResults.twoDaysOk).toBeTruthy();
   expect(hideResults.expiredOk).toBeTruthy();
+  expect(hideResults.unsnoozedOk).toBeTruthy();
 
   await page.reload();
   await ensureHiddenTrayOpen(page);
@@ -1254,7 +1265,11 @@ test('hidden tray shows hour labels under one day and day labels from one day on
 
   const expiredHiddenItem = page.locator('.hidden-tray-item', { hasText: expiredTitle }).first();
   await expect(expiredHiddenItem).toBeVisible();
-  await expect(expiredHiddenItem.locator('.hidden-tray-item__snooze')).toHaveCount(0);
+  await expect(expiredHiddenItem.locator('.hidden-tray-item__snooze')).toHaveText('Resurfaced');
+
+  const unsnoozedHiddenItem = page.locator('.hidden-tray-item', { hasText: unsnoozedTitle }).first();
+  await expect(unsnoozedHiddenItem).toBeVisible();
+  await expect(unsnoozedHiddenItem.locator('.hidden-tray-item__snooze')).toHaveCount(0);
 });
 
 test('hidden tray starts an hourly refresh interval while open', async ({ page }) => {

--- a/static/hidden_tray_state.js
+++ b/static/hidden_tray_state.js
@@ -77,19 +77,21 @@ export function createHiddenTrayController({
     }
     const msPerHour = 60 * 60 * 1000;
     const msPerDay = 24 * 60 * 60 * 1000;
-    const snoozeLabelFor = (item) => {
+    const snoozeBadgeFor = (item) => {
       const rawWakeAt = item && typeof item.snoozeWakeAt === 'string' ? item.snoozeWakeAt : '';
       if (!rawWakeAt) return null;
       const wakeAtMs = Date.parse(rawWakeAt);
       if (!Number.isFinite(wakeAtMs)) return null;
       const remainingMs = wakeAtMs - Date.now();
-      if (remainingMs <= 0) return null;
+      if (remainingMs <= 0) {
+        return { text: 'Resurfaced', kind: 'resurfaced' };
+      }
       if (remainingMs < msPerDay) {
         const hoursLeft = Math.max(1, Math.ceil(remainingMs / msPerHour));
-        return `${hoursLeft}h left`;
+        return { text: `${hoursLeft}h left`, kind: 'countdown' };
       }
       const daysLeft = Math.max(1, Math.ceil(remainingMs / msPerDay));
-      return `${daysLeft}d left`;
+      return { text: `${daysLeft}d left`, kind: 'countdown' };
     };
     hiddenItemsCache.forEach((item) => {
       const trayItem = document.createElement('div');
@@ -99,11 +101,14 @@ export function createHiddenTrayController({
       title.className = 'hidden-tray-item__title';
       title.textContent = item.title || 'Untitled';
       trayItem.appendChild(title);
-      const snoozeLabel = snoozeLabelFor(item);
-      if (snoozeLabel !== null) {
+      const snoozeBadge = snoozeBadgeFor(item);
+      if (snoozeBadge !== null) {
         const snooze = document.createElement('span');
         snooze.className = 'hidden-tray-item__snooze';
-        snooze.textContent = snoozeLabel;
+        if (snoozeBadge.kind === 'resurfaced') {
+          snooze.classList.add('hidden-tray-item__snooze--resurfaced');
+        }
+        snooze.textContent = snoozeBadge.text;
         trayItem.appendChild(snooze);
       }
       trayItem.draggable = true;

--- a/static/styles.css
+++ b/static/styles.css
@@ -175,6 +175,7 @@
 .hidden-tray-item:active{cursor:grabbing}
 .hidden-tray-item__title{min-width:0;flex:1 1 auto;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .hidden-tray-item__snooze{flex:0 0 auto;padding:2px 6px;border-radius:999px;background:rgba(86,107,174,.32);border:1px solid rgba(126,145,208,.52);color:#e5edff;font-size:10px;line-height:1.2;white-space:nowrap}
+.hidden-tray-item__snooze--resurfaced{background:rgba(74,138,118,.24);border-color:rgba(118,192,168,.58);color:#dcfff3}
 
 .hidden-tray-empty{font-size:12px;color:#aeb7d9;padding:6px 4px}
 


### PR DESCRIPTION
## Summary
- show `Resurfaced` badge in Hidden tray for expired snoozed cards
- keep `Xh left` / `Xd left` countdowns for future snoozed cards
- keep unsnoozed hidden cards without a badge
- add subtle resurfaced badge styling distinct from countdown badges

## Validation
- `npm run test:ui -- e2e/core-ui.spec.ts --grep "hidden tray shows snooze days-left only for snoozed cards|hidden tray shows countdown for future snoozes and Resurfaced badge for expired snoozes|hidden tray starts an hourly refresh interval while open"`
- `./scripts/lint-strict.sh`

## Issue
- Closes #92
