### PR TITLE
Fix stale+scope AND composition and widen chrome filters panel

### DIFF
--- a/docs/00-current-state.md
+++ b/docs/00-current-state.md
@@ -1,7 +1,7 @@
 # Orbit — 00 Current State (Canonical Baseline)
 
-Last reviewed: 2026-04-06  
-Review mode: legacy-to-current consolidation (human-confirmed)  
+Last reviewed: 2026-04-20  
+Review mode: canonical refresh after card-people-map initiative intake  
 Confidence: **high** on confirmed sections, **medium** where implementation verification is still pending
 
 ---
@@ -25,6 +25,9 @@ Primary evidence roots:
 - `docs/resurface-count/02-feature-spec.md`
 - `docs/chrome-context/02-feature-spec.md`
 - `docs/chrome-context/03-feature-spec-patch-tooltip.md`
+- `docs/card-people-map/01-discovery-handoff.md`
+- `docs/card-people-map/02-feature-spec.md`
+- `docs/card-people-map/03-spec-readiness-signoff.json`
 
 ---
 
@@ -127,6 +130,8 @@ Card action UI:
    - Current behavior is badge/state inside Hidden tray cards.
 3. **Deprecated:** treating web as primary end-user surface.  
    - Web is internal verification surface.
+4. **Not currently true:** card-people mapping/filtering is already shipped in product behavior.  
+   - Current status is specification-complete and implementation-ready under `docs/card-people-map/`, but not yet promoted as shipped truth in this canonical baseline.
 
 ---
 
@@ -134,6 +139,7 @@ Card action UI:
 
 1. Verify exact UI wording/token for days-left badge in Hidden tray (display format only; semantics already locked). (confidence: medium)
 2. Verify whether any implementation drift exists from locked behavior in latest build artifacts/tests. (confidence: medium)
+3. Implement and verify the `card-people-map` baseline (person-to-card mapping + single-select people filter); on completion, fold accepted behavior into Section 2 as currently true. (confidence: medium)
 
 ---
 

--- a/e2e/core-ui.spec.ts
+++ b/e2e/core-ui.spec.ts
@@ -1027,6 +1027,47 @@ test('stale lens shows only entry-time stale cards and refreshes on reload', asy
   expect(visible).toEqual([activeId!]);
 });
 
+test('stale lens composes with center/periphery scope without resetting scope', async ({ page }) => {
+  const centerTitle = `stale-scope-center-${Date.now()}`;
+  const peripheryTitle = `stale-scope-periphery-${Date.now()}`;
+
+  const centerPin = await createCard(page, centerTitle, 650, 340);
+  const peripheryPin = await createCard(page, peripheryTitle, 1120, 120);
+  const centerId = await centerPin.getAttribute('data-id');
+  const peripheryId = await peripheryPin.getAttribute('data-id');
+  expect(centerId).toBeTruthy();
+  expect(peripheryId).toBeTruthy();
+
+  ageCardInDb(centerId!, 8);
+  ageCardInDb(peripheryId!, 8);
+  await page.reload();
+
+  const centerReloaded = page.locator(`.pin[data-id="${centerId}"]`);
+  const peripheryReloaded = page.locator(`.pin[data-id="${peripheryId}"]`);
+  await expect(centerReloaded).toHaveAttribute('data-stale', 'true');
+  await expect(peripheryReloaded).toHaveAttribute('data-stale', 'true');
+
+  await ensureFiltersTrayOpen(page);
+  const centerLens = page.locator('.lens-btn[data-lens="center"]');
+  const peripheryLens = page.locator('.lens-btn[data-lens="periphery"]');
+  const staleLens = page.locator('.lens-btn[data-lens="stale"]');
+
+  await centerLens.click();
+  await staleLens.click();
+  await expect(centerLens).toHaveClass(/active/);
+  await expect(staleLens).toHaveClass(/active/);
+  let visible = await visiblePinIds(page);
+  expect(visible).toContain(centerId!);
+  expect(visible).not.toContain(peripheryId!);
+
+  await peripheryLens.click();
+  await expect(peripheryLens).toHaveClass(/active/);
+  await expect(staleLens).toHaveClass(/active/);
+  visible = await visiblePinIds(page);
+  expect(visible).toContain(peripheryId!);
+  expect(visible).not.toContain(centerId!);
+});
+
 test('card color change persists after reload', async ({ page }) => {
   const pin = await createCard(page, `color-${Date.now()}`, 1180, 240);
 

--- a/static/lens_state.js
+++ b/static/lens_state.js
@@ -10,7 +10,8 @@ export function createLensStateController({
 }) {
   const semanticContract = normalizeCenterSemantics(centerSemantics);
   const canonicalLensRatio = semanticContract ? semanticContract.lensRatio : 0.68;
-  let lens = readLensMode();
+  let staleActive = readStaleLensEnabled();
+  let scopeLens = 'all';
   let lensRatio = canonicalLensRatio;
   const lensExempt = new Set();
   let staleLensSnapshot = new Set();
@@ -43,28 +44,27 @@ export function createLensStateController({
     button.textContent = name[0].toUpperCase() + name.slice(1);
     button.onclick = () => {
       if (name === 'stale') {
-        setLensMode(lens === 'stale' ? 'all' : 'stale');
+        toggleStaleLens();
         return;
       }
-      setLensMode(name);
+      setScopeLens(name);
     };
     if (name === 'stale') lensWrap.appendChild(sliderWrap);
     lensWrap.appendChild(button);
   });
   filtersControls.appendChild(lensWrap);
 
-  function readLensMode() {
+  function readStaleLensEnabled() {
     try {
-      const stored = sessionStorage.getItem(LENS_MODE_STORAGE_KEY);
-      return stored === 'stale' ? 'stale' : 'all';
+      return sessionStorage.getItem(LENS_MODE_STORAGE_KEY) === 'stale';
     } catch (_err) {
-      return 'all';
+      return false;
     }
   }
 
   function persistLensMode() {
     try {
-      if (lens === 'stale') sessionStorage.setItem(LENS_MODE_STORAGE_KEY, 'stale');
+      if (staleActive) sessionStorage.setItem(LENS_MODE_STORAGE_KEY, 'stale');
       else sessionStorage.removeItem(LENS_MODE_STORAGE_KEY);
     } catch (_err) {}
   }
@@ -142,7 +142,7 @@ export function createLensStateController({
   }
 
   function syncStaleLensDom() {
-    if (lens !== 'stale') {
+    if (!staleActive) {
       restoreDetachedStalePins();
       return;
     }
@@ -158,12 +158,19 @@ export function createLensStateController({
     });
   }
 
-  function setLensMode(nextLens) {
-    lens = nextLens;
-    if (lens === 'stale') {
+  function setScopeLens(nextScopeLens) {
+    scopeLens = nextScopeLens;
+    renderButtons();
+    surface.querySelectorAll('.pin').forEach(applyDistanceStyle);
+    applyLens();
+    syncCanvasViewportRect();
+  }
+
+  function toggleStaleLens() {
+    staleActive = !staleActive;
+    if (staleActive) {
       captureStaleSnapshot();
     } else {
-      lensExempt.clear();
       staleLensSnapshot.clear();
       restoreDetachedStalePins();
     }
@@ -176,38 +183,36 @@ export function createLensStateController({
 
   function renderButtons() {
     document.querySelectorAll('.lens-btn').forEach((button) => {
-      button.classList.toggle('active', button.dataset.lens === lens);
+      if (button.dataset.lens === 'stale') {
+        button.classList.toggle('active', staleActive);
+        return;
+      }
+      button.classList.toggle('active', button.dataset.lens === scopeLens);
     });
     const slider = document.querySelector('.lens-slider-wrap');
-    if (slider) slider.hidden = (lens === 'all' || lens === 'stale');
+    if (slider) slider.hidden = (scopeLens === 'all');
     updateBoundaryCue(false);
   }
 
   function inLens(pin) {
-    if (lens === 'all') return true;
+    if (scopeLens === 'all') return true;
     const distance = pinDistanceFromCenter(pin);
     const cutoff = maxR() * lensRatio;
-    if (lens === 'center') return distance <= cutoff;
+    if (scopeLens === 'center') return distance <= cutoff;
     return distance > cutoff;
   }
 
   function isVisible(pin) {
     const id = pin.dataset.id;
-    let lensVisible = true;
-    if (lens !== 'all') {
-      if (lens === 'stale') lensVisible = staleLensSnapshot.has(id);
-      else lensVisible = lensExempt.has(id) || inLens(pin);
-    }
-    if (!lensVisible) return false;
+    const scopeVisible = (scopeLens === 'all') ? true : (lensExempt.has(id) || inLens(pin));
+    if (!scopeVisible) return false;
+    if (staleActive && !staleLensSnapshot.has(id)) return false;
     return additionalVisibilityPredicate(pin) !== false;
   }
 
   function applyLens() {
-    if (lens === 'stale') {
-      syncStaleLensDom();
-      return;
-    }
-    restoreDetachedStalePins();
+    if (staleActive) syncStaleLensDom();
+    else restoreDetachedStalePins();
     surface.querySelectorAll('.pin').forEach((pin) => {
       pin.style.display = isVisible(pin) ? '' : 'none';
     });
@@ -219,7 +224,7 @@ export function createLensStateController({
     surface.style.setProperty('--center-radius', radius + 'px');
     boundaryEl.style.width = (radius * 2) + 'px';
     boundaryEl.style.height = (radius * 2) + 'px';
-    const shouldShow = forceShow || dragHaloActive || (lens !== 'all' && lens !== 'stale');
+    const shouldShow = forceShow || dragHaloActive || (scopeLens !== 'all');
     boundaryEl.classList.toggle('show', shouldShow);
   }
 
@@ -241,7 +246,7 @@ export function createLensStateController({
     let bodySize = isCenterBand ? 11.7 : 10.7;
     let titleWeight = isCenterBand ? 660 : 560;
 
-    if (mode === 'focus' && lens === 'periphery' && !isCenterBand) {
+    if (mode === 'focus' && scopeLens === 'periphery' && !isCenterBand) {
       cardScale = Math.max(cardScale, 0.98);
       titleSize = Math.max(titleSize, 12.9);
       bodySize = Math.max(bodySize, 11.1);
@@ -283,7 +288,7 @@ export function createLensStateController({
   }
 
   function initialDisplayValue(pin, markSaved) {
-    return (lens === 'stale' ? isVisible(pin) : (!markSaved || isVisible(pin))) ? '' : 'none';
+    return (!markSaved || isVisible(pin)) ? '' : 'none';
   }
 
   function setAdditionalVisibilityPredicate(nextPredicate) {
@@ -297,7 +302,7 @@ export function createLensStateController({
     applyLens,
     captureStaleSnapshot,
     forgetPin,
-    getMode: () => lens,
+    getMode: () => (staleActive ? 'stale' : scopeLens),
     initialDisplayValue,
     isVisible,
     registerPin,

--- a/static/styles.css
+++ b/static/styles.css
@@ -132,7 +132,7 @@
 .filters-tray{position:relative;display:flex;align-items:flex-start;flex:none;max-width:100%}
 .filters-tray__toggle{position:relative;z-index:2;border:none;background:rgba(42,63,116,.75);color:#dce6ff;padding:4px 9px;border-radius:8px;font-size:11px;cursor:pointer;flex:none;white-space:nowrap}
 .filters-tray__toggle[aria-expanded="true"]{background:rgba(86,107,174,.8);color:#fff}
-.filters-tray__panel{position:static;z-index:40;display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:10px 11px;border:1px solid rgba(46,59,104,.56);border-radius:12px;background:rgba(10,14,26,.94);backdrop-filter:blur(10px);box-shadow:0 16px 32px rgba(0,0,0,.32);max-width:min(450px, calc(100vw - 24px));width:max-content}
+.filters-tray__panel{position:static;z-index:40;display:flex;flex-wrap:wrap;align-items:center;gap:8px;padding:10px 11px;border:1px solid rgba(46,59,104,.56);border-radius:12px;background:rgba(10,14,26,.94);backdrop-filter:blur(10px);box-shadow:0 16px 32px rgba(0,0,0,.32);max-width:min(560px, calc(100vw - 24px));width:max-content}
 .filters-tray__panel[hidden]{display:none}
 .filters-tray__controls{display:flex;flex-wrap:wrap;align-items:center;gap:8px;max-width:100%}
 .system-ack-stack{display:flex;justify-content:flex-end;align-items:flex-start;min-width:0;gap:8px;max-width:min(46%,560px);pointer-events:auto}


### PR DESCRIPTION
## Summary
- fix stale lens composition so Stale participates in strict AND with Center/Periphery scope
- preserve selected scope while stale is active (no implicit default-to-All)
- add e2e regression coverage for stale+scope composition behavior
- widen filters chrome panel max width to reduce People pill wrapping

## Verification
- go test ./...
- npm run test:ui -- --grep "stale lens composes with center/periphery scope without resetting scope|stale lens shows only entry-time stale cards and refreshes on reload"
- npm run test:ui -- --grep "people mapping supports create\+attach and single-select people filtering|people popup remains accessible near bottom edge|filters tray stays open on outside chrome clicks without losing active filter state"
